### PR TITLE
Add hust-oei 飞跃手册

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,10 +81,6 @@ CSAPP(计算机组成原理)实验 Github资源极多 自行搜索
 
 网络 [recolic](https://github.com/recolic/hust-networking)
 
-### OEI
-
-[华中科技大学OEI&SES飞跃手册](https://hust-feiyue.github.io)
-
 ### SE
 
 ----

--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ HustLaTeX模板库 [Github](https://github.com/hust-latex) [Website](https://hus
 
 毕业论文LaTeX模板 [本科-Github](https://github.com/skinaze/HUSTPaperTemp) [研究生-CTAN](https://ctan.org/pkg/hustthesis)
 
+[华中科技大学OEI&SES飞跃手册](https://hust-feiyue.github.io)
+
 ### CS 通用
 
 计科大多数实验的代码/报告 [husixu2](https://github.com/husixu1/HUST-Homeworks) [sabertazimi](https://github.com/sabertazimi/hust-lab)


### PR DESCRIPTION
[华中科技大学OEI&SES飞跃手册](https://hust-feiyue.github.io/)，对其他学院的也有参考价值。