### PR TITLE
更新微助教相关工具的信息

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,7 +120,9 @@ C语言实验自动评测系统漏洞笔记(还有一点其它东西) [Anonymous
 
 微助教自动签到/答题提醒工具(支持GPS签到+普通签到) [recolic](https://github.com/recolic/micro-teaching-assistant-fucker)
 
-新版微助教自动签到/讨论提醒(支持二维码签到+GPS签到+普通签到) [wzj-sign-in-weixin](https://github.com/yun-mu/wzj-sign-in-weixin) (已上线微信后台，可直接关注使用)
+又一个微助教工具（支持普通/GPS/二维码签到）[yatm](https://github.com/ManiaciaChao/yatm)
+
+微助教自动签到/讨论提醒(支持GPS签到+普通签到) [wzj-sign-in-weixin](https://github.com/yun-mu/wzj-sign-in-weixin)<del> (已上线微信后台，可直接关注使用)</del>
 
 Polyv-cn平台网络课程自动签到脚本 [polyv-fucker](https://github.com/ttzztztz/polyv-fucker)
 

--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ CSAPP(计算机组成原理)实验 Github资源极多 自行搜索
 
 Polyv-cn平台网络课程自动签到脚本 [polyv-fucker](https://github.com/ttzztztz/polyv-fucker)
 
-新版(2020)统一身份认证登录库 (python) [libhustpass](https://github.com/naivekun/libhustpass)
+新版(2020)统一身份认证登录库 [libhustpass (Python)](https://github.com/naivekun/libhustpass)  [node-hustpass (Node.js)](https://github.com/ManiaciaChao/node-hustpass)
 
 SARS-CoV-2每日健康状况自动上报 [recolic](https://git.recolic.net/recolic-hust/hust-2019-ncov-submit-fucker) [misaka7690的改进版本](https://github.com/misaka7690/HUST-2019-ncov-submit-fucker)
 

--- a/README.md
+++ b/README.md
@@ -153,13 +153,9 @@ CSAPP(计算机组成原理)实验 Github资源极多 自行搜索
 
 Polyv-cn平台网络课程自动签到脚本 [polyv-fucker](https://github.com/ttzztztz/polyv-fucker)
 
-新版(2020)统一身份认证登录库 [libhustpass (Python)](https://github.com/naivekun/libhustpass)  [node-hustpass (Node.js)](https://github.com/ManiaciaChao/node-hustpass)
+新版(2020)统一身份认证登录库 [libhustpass(Python)](https://github.com/naivekun/libhustpass)  [node-hustpass(Node.js)](https://github.com/ManiaciaChao/node-hustpass)
 
 SARS-CoV-2每日健康状况自动上报 [recolic](https://git.recolic.net/recolic-hust/hust-2019-ncov-submit-fucker) [misaka7690的改进版本](https://github.com/misaka7690/HUST-2019-ncov-submit-fucker)
-
-QQ网页扫码登录（适用于空间和邮箱） [qq-qr-login](https://github.com/ManiaciaChao/qq-qr-login)
-
-QQ群文件批量下载（用于同步课程群课件） [qq-group-cli](https://github.com/ManiaciaChao/qq-group-cli)
 
 ### CS/SE only
 

--- a/README.md
+++ b/README.md
@@ -157,6 +157,10 @@ Polyv-cn平台网络课程自动签到脚本 [polyv-fucker](https://github.com/t
 
 SARS-CoV-2每日健康状况自动上报 [recolic](https://git.recolic.net/recolic-hust/hust-2019-ncov-submit-fucker) [misaka7690的改进版本](https://github.com/misaka7690/HUST-2019-ncov-submit-fucker)
 
+QQ网页扫码登录（适用于空间和邮箱） [qq-qr-login](https://github.com/ManiaciaChao/qq-group-cli)
+
+QQ群文件批量下载（用于同步课程群课件） [qq-group-cli](https://github.com/ManiaciaChao/qq-group-cli)
+
 ### CS/SE only
 
 Vivado Wrapper For Linux CommandLine [vivado-wrapper](https://github.com/recolic/vivado-wrapper) [AUR](https://aur.archlinux.org/packages/vivado-wrapper)

--- a/README.md
+++ b/README.md
@@ -157,7 +157,7 @@ Polyv-cn平台网络课程自动签到脚本 [polyv-fucker](https://github.com/t
 
 SARS-CoV-2每日健康状况自动上报 [recolic](https://git.recolic.net/recolic-hust/hust-2019-ncov-submit-fucker) [misaka7690的改进版本](https://github.com/misaka7690/HUST-2019-ncov-submit-fucker)
 
-QQ网页扫码登录（适用于空间和邮箱） [qq-qr-login](https://github.com/ManiaciaChao/qq-group-cli)
+QQ网页扫码登录（适用于空间和邮箱） [qq-qr-login](https://github.com/ManiaciaChao/qq-qr-login)
 
 QQ群文件批量下载（用于同步课程群课件） [qq-group-cli](https://github.com/ManiaciaChao/qq-group-cli)
 


### PR DESCRIPTION
* [wzj-sign-in-weixin](https://github.com/yun-mu/wzj-sign-in-weixin) 的微信公众号服务已不可用，且review代码后认为其并不支持二维码签到。移除了相关描述。
* 添加了自用的 [yatm](https://github.com/ManiaciaChao/yatm)