### PR TITLE
增加完善的华中大绿色通行码生成

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Polyv-cn平台网络课程自动签到脚本 [polyv-fucker](https://github.com/t
 
 SARS-CoV-2每日健康状况自动上报 [recolic](https://git.recolic.net/recolic-hust/hust-2019-ncov-submit-fucker) [misaka7690的改进版本](https://github.com/misaka7690/HUST-2019-ncov-submit-fucker) [winderica的无GUI版本](https://github.com/winderica/DailyReport)
 
-华中大绿色通行码生成 [xylonx的Nodejs版](https://github.com/xylonx/access-qrcode-fxxker)
+华中大绿色通行码生成 [xylonx的Nodejs版](https://github.com/xylonx/access-qrcode-fxxker) [CGSportFucker-已部署到GitHubPages](https://cgsportfucker.github.io/HQPC-Fucker/)
 
 百度文档免券下载(已上云,支持原格式) [gufeijun](https://github.com/gufeijun/baiduwenku-go)
 


### PR DESCRIPTION
已部署到GitHub Pages，输入信息即可获得高仿页面