### PR TITLE
Update 2023版python统一认证库

### DIFF
--- a/README.md
+++ b/README.md
@@ -206,8 +206,6 @@ Polyv-cn平台网络课程自动签到脚本 [polyv-fucker](https://github.com/t
 
 华中大微校园-应用中心 [不必使用微信打开](http://m.hust.edu.cn/wechat/apps_center.jsp)
 
-新版(2020)统一身份认证登录库 [libhustpass(Python)](https://github.com/naivekun/libhustpass)  [node-hustpass(Node.js)](https://github.com/ManiaciaChao/node-hustpass) (均已失效)
-
 新版(2023)统一身份认证登录库 [HustPass2023(Python)](https://github.com/MarvinTerry/HustLogin)
 
 军理/军事理论电子电气资源网线上作业答案自动填充脚本 [gongchen618](https://github.com/gongchen618/HUST-MT-Helper)

--- a/README.md
+++ b/README.md
@@ -206,7 +206,9 @@ Polyv-cn平台网络课程自动签到脚本 [polyv-fucker](https://github.com/t
 
 华中大微校园-应用中心 [不必使用微信打开](http://m.hust.edu.cn/wechat/apps_center.jsp)
 
-新版(2020)统一身份认证登录库 [libhustpass(Python)](https://github.com/naivekun/libhustpass)  [node-hustpass(Node.js)](https://github.com/ManiaciaChao/node-hustpass)
+新版(2020)统一身份认证登录库 [libhustpass(Python)](https://github.com/naivekun/libhustpass)  [node-hustpass(Node.js)](https://github.com/ManiaciaChao/node-hustpass) (均已失效)
+
+新版(2023)统一身份认证登录库 [HustPass2023(Python)](https://github.com/MarvinTerry/HustLogin)
 
 军理/军事理论电子电气资源网线上作业答案自动填充脚本 [gongchen618](https://github.com/gongchen618/HUST-MT-Helper)
 


### PR DESCRIPTION
华科统一认证系统于2023/5/23进行了升级，加密算法由DES改为AES，因此重写了一版适用于2023的统一认证库，之前的2020版库均已失效。
已打包上传PyPI，```pip install hust_login```即可。
重写的新版认证库更加方便，```hust_login.HustPass(usr,pass)```直接返回登录完成的```Requests.Session```对象，可直接用来访问任何需要统一认证的网站和API。